### PR TITLE
fix: Omitir build del SDK para evitar errores de memoria en Render

### DIFF
--- a/.render/project-build.sh
+++ b/.render/project-build.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
 corepack enable
+
 pnpm install --no-frozen-lockfile
 
-cd app/javascript
+# 🚫 Saltamos la compilación del SDK para evitar errores de memoria
+# cd app/javascript
+# NODE_OPTIONS="--max-old-space-size=8192" pnpm run build:sdk
+# cd ../../
 
-# ✅ Ahora el build:sdk usa la variable correctamente
-NODE_OPTIONS=--max-old-space-size=16384 pnpm run build:sdk
-
-cd ../../
-
+# ✅ Instala las gems necesarias
 bundle config set --local path 'vendor/bundle'
 bundle install --jobs 4 --retry 3
 
+# ✅ Precompila assets
 RAILS_ENV=production bundle exec rake assets:precompile
 
 echo "✅ Build terminado correctamente"

--- a/.render/project-build.sh
+++ b/.render/project-build.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-set -e
 
-echo "🚀 Paso 1: Compilando SDK de Chatwoot..."
+corepack enable
+pnpm install --no-frozen-lockfile
+
+cd app/javascript
+
+# ✅ Ahora el build:sdk usa la variable correctamente
 NODE_OPTIONS=--max-old-space-size=16384 pnpm run build:sdk
-echo "✅ SDK compilado."
 
-echo "🚀 Paso 2: Compilando assets con SECRET_KEY_BASE..."
-SECRET_KEY_BASE=6ee24b067db20b5d9896d6d60159fa8ede75f3a8e343b955f9e77825030d938cb37ef77784c0112ebf918ae13a90e2919f401a6f1eddff52f7210c4901b64fba \
-NODE_OPTIONS=--max-old-space-size=2048 \
+cd ../../
+
+bundle config set --local path 'vendor/bundle'
+bundle install --jobs 4 --retry 3
+
 RAILS_ENV=production bundle exec rake assets:precompile
 
-echo "✅ Assets compilados. Build finalizado 🎉"
+echo "✅ Build terminado correctamente"


### PR DESCRIPTION
# Pull Request Template

## Description


Este PR modifica el archivo .render/project-build.sh para omitir la compilación del SDK de JavaScript (pnpm run build:sdk) durante el build en Render.

Esto evita los errores por falta de memoria (JavaScript heap out of memory) que provocaban fallas durante la compilación con Vite.

Se mantiene la precompilación de assets (rake assets:precompile), que es necesaria para que el frontend funcione correctamente.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

El codigo fue testeado haciendo un deploy manual en render

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
